### PR TITLE
Schedulesのactivehashを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 gem 'pry-rails'
+gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_hash (3.1.1)
+      activesupport (>= 5.0.0)
     activejob (6.0.5.1)
       activesupport (= 6.0.5.1)
       globalid (>= 0.3.6)
@@ -269,6 +271,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/app/models/accuracy.rb
+++ b/app/models/accuracy.rb
@@ -1,0 +1,12 @@
+class Accuracy < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '仮予約' },
+    { id: 3, name: '本予約' },
+    { id: 4, name: 'その他' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :schedules
+
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,2 +1,9 @@
 class Schedule < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to :size
+  belongs_to :accuracy
+  belongs_to :time_zone
+
+  #空の投稿を保存できないようにする
+  validates :saize_id, :accuracy_id, :time_zone, numericality: { other_than: 1 }, presence: true
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -5,5 +5,5 @@ class Schedule < ApplicationRecord
   belongs_to :time_zone
 
   #空の投稿を保存できないようにする
-  validates :saize_id, :accuracy_id, :time_zone, numericality: { other_than: 1 }, presence: true
+  validates :saize_id, :accuracy_id, :time_zone, numericality: { other_than: 1 , message: "can't be blank"}, presence: true
 end

--- a/app/models/size.rb
+++ b/app/models/size.rb
@@ -1,0 +1,13 @@
+class Size < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '小口径' },
+    { id: 3, name: '中口径' },
+    { id: 4, name: '大口径' },
+    { id: 5, name: 'その他' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :schedules
+
+end

--- a/app/models/time_zone.rb
+++ b/app/models/time_zone.rb
@@ -1,0 +1,14 @@
+class TimeZone < ActiveHash::Base
+  self.data = [
+    { id: 1, name: '---' },
+    { id: 2, name: '午前' },
+    { id: 3, name: '午後' },
+    { id: 4, name: '午前・午後' },
+    { id: 5, name: '夜間' },
+    { id: 6, name: 'その他' }
+  ]
+
+  include ActiveHash::Associations
+  has_many :schedules
+
+end


### PR DESCRIPTION
# What
- アクティブハッシュの作成
- scheduleモデルの変更
# Why
- 工事予約機能の実装に先立って
# その他
- アクティブハッシュ終了のコミット後に、GithubDesktopからプルリクエストを送った
- web上ではプルリクエストの作成をしていない
- その状態で、エラーメッセージ記入のコミット後に、GithubDesktopからプルリクエストを送った